### PR TITLE
Add `sbt-version-policy` plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,11 @@
-ThisBuild / scalaVersion       := "2.13.12"
-ThisBuild / crossScalaVersions := Seq("2.13.12", "3.3.0")
-ThisBuild / organization       := "com.permutive"
+ThisBuild / scalaVersion           := "2.13.12"
+ThisBuild / crossScalaVersions     := Seq("2.13.12", "3.3.0")
+ThisBuild / organization           := "com.permutive"
+ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
 
-addCommandAlias("ci-test", "fix --check; mdoc; publishLocal; +test")
+addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; +test")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
-addCommandAlias("ci-publish", "github; ci-release")
+addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 
 lazy val documentation = project
   .enablePlugins(MdocPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,6 +10,7 @@ addSbtPlugin("com.alejandrohdezma"               % "sbt-modules"           % "0.
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings"      % "3.0.2")
 addSbtPlugin("com.github.sbt"                    % "sbt-ci-release"        % "1.5.12")
 addSbtPlugin("de.heikoseeberger"                 % "sbt-header"            % "5.10.0")
+addSbtPlugin("ch.epfl.scala"                     % "sbt-version-policy"    % "3.2.0")
 addSbtPlugin("org.typelevel"                     % "sbt-tpolecat"          % "0.5.0")
 addSbtPlugin("org.scalameta"                     % "sbt-mdoc"              % "2.5.1")
 addSbtPlugin("org.scalameta"                     % "sbt-scalafmt"          % "2.5.2")


### PR DESCRIPTION
From `sbt-version-policy`'s README:

> sbt-version-policy helps library maintainers to follow the [recommended versioning scheme].
> This plugin:
> 
> - configures [MiMa] to check for binary or source incompatibilities,
> - ensures that none of your dependencies are bumped or removed in an incompatible way,
> - reports incompatibilities with previous releases,
> - sets the [`versionScheme`](https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme) of the project to `"early-semver"`.

More information on this plugin can be found [here](https://github.com/scalacenter/sbt-version-policy).