### PR TITLE
Add `TokenProvider.auto` for ADC-style provider selection

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -139,6 +139,25 @@ TokenProvider.userAccount[IO](
 TokenProvider.userAccount[IO](httpClient)
 ```
 
+#### Auto-selection via Application Default Credentials
+
+`TokenProvider.auto` picks the right token provider using Google's standard
+[ADC precedence] — useful when the same binary runs locally (user account),
+in CI (service-account JSON via `GOOGLE_APPLICATION_CREDENTIALS`), and in
+production (workload identity on GCE/GKE).
+
+```scala mdoc:silent
+import com.permutive.gcp.auth.TokenProvider
+
+TokenProvider.auto[IO](httpClient)
+
+// or, with explicit scopes for the service-account JSON branch:
+TokenProvider.auto[IO](
+    scopes = "https://www.googleapis.com/auth/bigquery" :: Nil,
+    httpClient = httpClient
+)
+```
+
 ### Reading the authenticated principal
 
 Every `TokenProvider` exposes a `principal: F[Option[String]]` accessor that
@@ -271,4 +290,5 @@ val identityTokenProvider = config.tokenType.identityTokenProvider(httpClient, m
 [Google User Account Token]: https://developers.google.com/identity/protocols/OAuth2WebServer
 [Identity Token]: https://cloud.google.com/run/docs/securing/service-identity#fetching_identity_and_access_tokens_using_the_metadata_server
 [instance metadata API]: https://cloud.google.com/compute/docs/access/authenticate-workloads
+[ADC precedence]: https://cloud.google.com/docs/authentication/provide-credentials-adc
 [pureconfig]: https://pureconfig.github.io

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -158,6 +158,22 @@ TokenProvider.auto[IO](
 )
 ```
 
+##### Disabling `auto` in acceptance tests
+
+Setting the `GCP_AUTH_DISABLE=true` environment variable (or the
+equivalent `gcp.auth.disable=true` JVM system property) makes every
+`TokenProvider.auto` overload short-circuit to
+`TokenProvider.const(AccessToken.noop)` — no filesystem reads, no
+metadata-server probes. Useful for acceptance tests that need to
+silence credential resolution without otherwise touching the
+application wiring.
+
+**Caveat:** a stray production setting will silently produce a no-op
+provider instead of a loud "credentials not found" error. When the
+configuration channel can be controlled per environment, prefer the
+`gcp-auth-pureconfig` integration with `TokenType.NoOp` selected via
+`application.conf`.
+
 ### Reading the authenticated principal
 
 Every `TokenProvider` exposes a `principal: F[Option[String]]` accessor that

--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -150,8 +150,11 @@ returns the subject identifier the provider is authenticated as:
 - **User-account flows** do a best-effort call to Google's `userinfo`
   endpoint and return `None` if the call fails (the refresh token may have
   been issued with scopes that don't include `email`/`openid`/`profile`).
-- **Identity-token flows** decode the issued JWT and return its `email`
-  (falling back to `sub`) claim, or `None` if neither is present.
+- **`identity` (workload identity token)** hits the GCE metadata server's
+  `/email` endpoint, mirroring the service-account workload flow.
+- **`userIdentity` (user-account identity token)** decodes the issued JWT
+  and returns its `email` claim (falling back to `sub`), or `None` if
+  neither is present.
 - `TokenProvider.const` and `TokenProvider.create` return `None`.
 
 Factories that need an HTTP call to resolve the principal memoise the

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
@@ -472,4 +472,66 @@ object TokenProvider {
 
   }
 
+  /** Default OAuth2 scope used by `auto` when none is supplied: grants access to all GCP services the underlying
+    * credentials are entitled to.
+    */
+  val DefaultScope: String = "https://www.googleapis.com/auth/cloud-platform"
+
+  /** Auto-selects an appropriate [[TokenProvider]] using Google's standard "Application Default Credentials"
+    * precedence:
+    *
+    *   1. `GOOGLE_APPLICATION_CREDENTIALS` env var pointing to a credentials JSON file (dispatching on the JSON's
+    *      `type` field — `service_account` or `authorized_user`)
+    *   2. `~/.config/gcloud/application_default_credentials.json` (or `%AppData%/gcloud/...` on Windows)
+    *   3. The compute-engine metadata server (workload identity)
+    *
+    * Equivalent in spirit to Google's `GoogleCredentials.getApplicationDefault()`. The returned provider memoises
+    * [[TokenProvider!.principal principal]], so each instance makes at most one underlying lookup.
+    *
+    * Raises [[com.permutive.gcp.auth.errors.UnsupportedCredentialsType UnsupportedCredentialsType]] when the
+    * credentials file declares a `type` other than `service_account` or `authorized_user` (e.g. `external_account`,
+    * `impersonated_service_account`, `gdch_service_account`).
+    *
+    * @see
+    *   https://cloud.google.com/docs/authentication/provide-credentials-adc
+    */
+  def auto[F[_]: Async: Files](httpClient: Client[F]): F[TokenProvider[F]] =
+    auto(DefaultScope :: Nil, httpClient)
+
+  /** Same as the zero-scope `auto` overload, but with explicit OAuth2 scopes for the service-account JSON branch.
+    * Scopes are ignored when dispatching to user-account or metadata-server flows.
+    */
+  def auto[F[_]: Async: Files](scopes: List[String], httpClient: Client[F]): F[TokenProvider[F]] =
+    Parser.defaultCredentialsFile[F].flatMap {
+      case (_, Some(Parser.CredentialsFile.ServiceAccount(email, key))) =>
+        serviceAccount(email, key, scopes, httpClient).pure[F]
+      case (_, Some(Parser.CredentialsFile.AuthorizedUser(clientId, secret, refreshToken))) =>
+        userAccount(clientId, secret, refreshToken, httpClient)
+      case (_, None) =>
+        serviceAccount(httpClient)
+    }
+
+  /** Auto-selects an appropriate identity-token [[TokenProvider]] using Google's standard "Application Default
+    * Credentials" precedence:
+    *
+    *   1. `GOOGLE_APPLICATION_CREDENTIALS` env var, or `~/.config/gcloud/application_default_credentials.json` (or
+    *      `%AppData%/gcloud/...` on Windows) — uses `userIdentity` to exchange the ADC user's refresh token for an
+    *      id_token (dev-only). Requires the file to be of type `authorized_user`.
+    *   2. The compute-engine metadata server (workload identity) — uses [[identity]] for the given audience.
+    *
+    * Identity tokens via service-account JSON files are not supported by this library.
+    *
+    * Raises [[com.permutive.gcp.auth.errors.UnsupportedCredentialsType UnsupportedCredentialsType]] when the
+    * credentials file declares a `type` other than `authorized_user`.
+    */
+  def auto[F[_]: Async: Files](httpClient: Client[F], audience: Uri): F[TokenProvider[F]] =
+    Parser.defaultCredentialsFile[F].flatMap {
+      case (_, Some(Parser.CredentialsFile.AuthorizedUser(clientId, secret, refreshToken))) =>
+        userIdentity(clientId, secret, refreshToken, httpClient)
+      case (path, Some(_: Parser.CredentialsFile.ServiceAccount)) =>
+        new UnsupportedCredentialsType(path, "service_account").raiseError[F, TokenProvider[F]]
+      case (_, None) =>
+        identity(httpClient, audience)
+    }
+
 }

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
@@ -244,46 +244,65 @@ object TokenProvider {
   def userIdentity[F[_]: Async: Files](httpClient: Client[F]): F[TokenProvider[F]] =
     Parser.defaultCredentialsFile[F].flatMap {
       case (_, Some(Parser.CredentialsFile.AuthorizedUser(clientId, clientSecret, refreshToken))) =>
-        val fetchToken: F[AccessToken] = {
-          val form = UrlForm(
-            "refresh_token" -> refreshToken.value,
-            "client_id"     -> clientId.value,
-            "client_secret" -> clientSecret.value,
-            "grant_type"    -> "refresh_token"
-          )
-
-          val request = Request[F](POST, uri"https://oauth2.googleapis.com/token").withEntity(form)
-
-          val decoder = Decoder.forProduct2("id_token", "expires_in")(AccessToken.apply)
-
-          httpClient
-            .expect[Json](request)
-            .flatMap(_.as[AccessToken](decoder).liftTo[F])
-            .adaptError { case t => new UnableToGetToken(t) }
-        }
-
-        val fetchPrincipal =
-          fetchToken.map { token =>
-            val parts = token.token.value.split('.')
-
-            if (parts.length < 2) Option.empty[String]
-            else {
-              val payloadJson = new String(Base64.getUrlDecoder.decode(parts(1)), UTF_8)
-              parser
-                .parse(payloadJson)
-                .toOption
-                .flatMap(json => json.hcursor.get[String]("email").orElse(json.hcursor.get[String]("sub")).toOption)
-            }
-          }.handleError(_ => None)
-
-        Concurrent[F]
-          .memoize(fetchPrincipal)
-          .map(TokenProvider.create[F](fetchToken).withPrincipal(_))
+        userIdentity(clientId, clientSecret, refreshToken, httpClient)
       case (path, Some(_: Parser.CredentialsFile.ServiceAccount)) =>
         new UnsupportedCredentialsType(path, "service_account").raiseError[F, TokenProvider[F]]
       case (_, None) =>
         DefaultCredentialsFileNotFound.raiseError[F, TokenProvider[F]]
     }
+
+  /** Retrieves an identity token from Google's OAuth API by exchanging an explicit user-account refresh token.
+    *
+    * Identity tokens can be used for calling Cloud Run services.
+    *
+    * '''Warning!''' Be sure to keep these tokens secure, and never use them in a production environment. They are meant
+    * to be used during development only.
+    *
+    * @see
+    *   https://cloud.google.com/run/docs/securing/service-identity#fetching_identity_and_access_tokens_using_the_metadata_server
+    */
+  def userIdentity[F[_]: Concurrent](
+      clientId: ClientId,
+      clientSecret: ClientSecret,
+      refreshToken: RefreshToken,
+      httpClient: Client[F]
+  ): F[TokenProvider[F]] = {
+    val fetchToken: F[AccessToken] = {
+      val form = UrlForm(
+        "refresh_token" -> refreshToken.value,
+        "client_id"     -> clientId.value,
+        "client_secret" -> clientSecret.value,
+        "grant_type"    -> "refresh_token"
+      )
+
+      val request = Request[F](POST, uri"https://oauth2.googleapis.com/token").withEntity(form)
+
+      val decoder = Decoder.forProduct2("id_token", "expires_in")(AccessToken.apply)
+
+      httpClient
+        .expect[Json](request)
+        .flatMap(_.as[AccessToken](decoder).liftTo[F])
+        .adaptError { case t => new UnableToGetToken(t) }
+    }
+
+    val fetchPrincipal =
+      fetchToken.map { token =>
+        val parts = token.token.value.split('.')
+
+        if (parts.length < 2) Option.empty[String]
+        else {
+          val payloadJson = new String(Base64.getUrlDecoder.decode(parts(1)), UTF_8)
+          parser
+            .parse(payloadJson)
+            .toOption
+            .flatMap(json => json.hcursor.get[String]("email").orElse(json.hcursor.get[String]("sub")).toOption)
+        }
+      }.handleError(_ => None)
+
+    Concurrent[F]
+      .memoize(fetchPrincipal)
+      .map(TokenProvider.create[F](fetchToken).withPrincipal(_))
+  }
 
   /** Retrieves a workload service account token using Google's metadata server.
     *

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
@@ -63,6 +63,7 @@ import org.http4s.Uri
 import org.http4s.UrlForm
 import org.http4s.circe._
 import org.http4s.client.Client
+import org.http4s.jdkhttpclient.JdkHttpClient
 import org.http4s.syntax.all._
 import org.typelevel.ci._
 import pdi.jwt.JwtCirce
@@ -533,5 +534,23 @@ object TokenProvider {
       case (_, None) =>
         identity(httpClient, audience)
     }
+
+  /** Same as `auto(httpClient)` but allocates a default [[org.http4s.jdkhttpclient.JdkHttpClient JdkHttpClient]]
+    * internally and returns the result as a `Resource` so the client is released alongside the provider.
+    */
+  def auto[F[_]: Async: Files]: Resource[F, TokenProvider[F]] =
+    JdkHttpClient.simple[F].evalMap(auto[F])
+
+  /** Same as `auto(scopes, httpClient)` but allocates a default
+    * [[org.http4s.jdkhttpclient.JdkHttpClient JdkHttpClient]] internally.
+    */
+  def auto[F[_]: Async: Files](scopes: List[String]): Resource[F, TokenProvider[F]] =
+    JdkHttpClient.simple[F].evalMap(auto[F](scopes, _))
+
+  /** Same as `auto(httpClient, audience)` but allocates a default
+    * [[org.http4s.jdkhttpclient.JdkHttpClient JdkHttpClient]] internally.
+    */
+  def auto[F[_]: Async: Files](audience: Uri): Resource[F, TokenProvider[F]] =
+    JdkHttpClient.simple[F].evalMap(auto[F](_, audience))
 
 }

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
@@ -26,11 +26,13 @@ import java.util.Date
 import scala.concurrent.duration._
 
 import cats.Applicative
+import cats.data.OptionT
 import cats.effect.Async
 import cats.effect.Clock
 import cats.effect.Concurrent
 import cats.effect.MonadCancelThrow
 import cats.effect.Resource
+import cats.effect.Sync
 import cats.effect.Temporal
 import cats.effect.syntax.all._
 import cats.syntax.all._
@@ -473,6 +475,21 @@ object TokenProvider {
 
   }
 
+  /** Short-circuit hook used by every `auto` overload. Reads the `gcp.auth.disable` JVM system property first, falling
+    * back to the `GCP_AUTH_DISABLE` environment variable. When either is set to a case-insensitive `"true"`, returns a
+    * no-op provider backed by [[com.permutive.gcp.auth.models.AccessToken.noop AccessToken.noop]] without evaluating
+    * `fallback` — so no filesystem reads, no metadata-server probes, no HTTP calls. Otherwise delegates to `fallback`.
+    *
+    * Intended for acceptance tests that need to silence credential resolution without otherwise touching the
+    * application wiring. See the Scaladoc on [[auto]] for the trade-off (a stray production setting silently produces a
+    * no-op provider).
+    */
+  private def disabledOr[F[_]: Sync](fallback: F[TokenProvider[F]]): F[TokenProvider[F]] =
+    OptionT(Sync[F].delay(sys.props.get("gcp.auth.disable")))
+      .orElse(OptionT(Sync[F].delay(sys.env.get("GCP_AUTH_DISABLE"))))
+      .exists(_.equalsIgnoreCase("true"))
+      .ifM(TokenProvider.const[F](AccessToken.noop).pure[F], fallback)
+
   /** Default OAuth2 scope used by `auto` when none is supplied: grants access to all GCP services the underlying
     * credentials are entitled to.
     */
@@ -493,6 +510,10 @@ object TokenProvider {
     * credentials file declares a `type` other than `service_account` or `authorized_user` (e.g. `external_account`,
     * `impersonated_service_account`, `gdch_service_account`).
     *
+    * Honors `GCP_AUTH_DISABLE=true` or `gcp.auth.disable=true` environment variables or system properties. When either
+    * is set, every overload returns [[const]] of [[com.permutive.gcp.auth.models.AccessToken.noop AccessToken.noop]]
+    * without doing any I/O.
+    *
     * @see
     *   https://cloud.google.com/docs/authentication/provide-credentials-adc
     */
@@ -502,7 +523,7 @@ object TokenProvider {
   /** Same as the zero-scope `auto` overload, but with explicit OAuth2 scopes for the service-account JSON branch.
     * Scopes are ignored when dispatching to user-account or metadata-server flows.
     */
-  def auto[F[_]: Async: Files](scopes: List[String], httpClient: Client[F]): F[TokenProvider[F]] =
+  def auto[F[_]: Async: Files](scopes: List[String], httpClient: Client[F]): F[TokenProvider[F]] = disabledOr[F] {
     Parser.defaultCredentialsFile[F].flatMap {
       case (_, Some(Parser.CredentialsFile.ServiceAccount(email, key))) =>
         serviceAccount(email, key, scopes, httpClient).pure[F]
@@ -511,6 +532,7 @@ object TokenProvider {
       case (_, None) =>
         serviceAccount(httpClient)
     }
+  }
 
   /** Auto-selects an appropriate identity-token [[TokenProvider]] using Google's standard "Application Default
     * Credentials" precedence:
@@ -524,8 +546,10 @@ object TokenProvider {
     *
     * Raises [[com.permutive.gcp.auth.errors.UnsupportedCredentialsType UnsupportedCredentialsType]] when the
     * credentials file declares a `type` other than `authorized_user`.
+    *
+    * Honors `GCP_AUTH_DISABLE=true` or `gcp.auth.disable=true` environment variables or system properties.
     */
-  def auto[F[_]: Async: Files](httpClient: Client[F], audience: Uri): F[TokenProvider[F]] =
+  def auto[F[_]: Async: Files](httpClient: Client[F], audience: Uri): F[TokenProvider[F]] = disabledOr[F] {
     Parser.defaultCredentialsFile[F].flatMap {
       case (_, Some(Parser.CredentialsFile.AuthorizedUser(clientId, secret, refreshToken))) =>
         userIdentity(clientId, secret, refreshToken, httpClient)
@@ -534,6 +558,7 @@ object TokenProvider {
       case (_, None) =>
         identity(httpClient, audience)
     }
+  }
 
   /** Same as `auto(httpClient)` but allocates a default [[org.http4s.jdkhttpclient.JdkHttpClient JdkHttpClient]]
     * internally and returns the result as a `Resource` so the client is released alongside the provider.

--- a/modules/gcp-auth/src/test/resources/default/missing/placeholder.txt
+++ b/modules/gcp-auth/src/test/resources/default/missing/placeholder.txt
@@ -1,0 +1,1 @@
+This directory intentionally lacks .config/gcloud/application_default_credentials.json

--- a/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
+++ b/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
@@ -27,7 +27,9 @@ import cats.syntax.all._
 
 import com.permutive.gcp.auth.errors.DefaultCredentialsFileNotFound
 import com.permutive.gcp.auth.errors.UnableToGetClientData
+import com.permutive.gcp.auth.errors.UnableToGetDefaultCredentials
 import com.permutive.gcp.auth.errors.UnableToGetToken
+import com.permutive.gcp.auth.errors.UnsupportedCredentialsType
 import com.permutive.gcp.auth.models.AccessToken
 import com.permutive.gcp.auth.models.ClientEmail
 import com.permutive.gcp.auth.models.ClientId
@@ -442,6 +444,140 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .flatMap(_.principal)
 
     assertIO(result, None)
+  }
+
+  ////////////////////////////////////
+  // TokenProvider.auto             //
+  ////////////////////////////////////
+
+  fixture("/default/valid").test("TokenProvider.auto routes to userAccount when ADC user file exists") { _ =>
+    val client = Client.from {
+      case POST -> Root / "token" =>
+        Ok(Json.obj("access_token" := "user-token", "expires_in" := 3600))
+      case req @ GET -> Root / "oauth2" / "v3" / "userinfo" if req.hasHeader("Authorization", "Bearer user-token") =>
+        Ok(Json.obj("email" := "adc-user@example.com"))
+    }
+
+    val result = TokenProvider.auto[IO](client).flatMap { provider =>
+      (provider.accessToken, provider.principal).tupled
+    }
+
+    assertIO(result, (AccessToken(Token("user-token"), ExpiresIn(3600)), Some("adc-user@example.com")))
+  }
+
+  fixture("/default/sa-valid").test("TokenProvider.auto routes to serviceAccount when ADC SA file exists") { _ =>
+    val client = Client.from { case POST -> Root / "token" =>
+      Ok(Json.obj("access_token" := "sa-token", "expires_in" := 3600))
+    }
+
+    val result = TokenProvider.auto[IO](client).flatMap { provider =>
+      (provider.accessToken, provider.principal).tupled
+    }
+
+    assertIO(result, (AccessToken(Token("sa-token"), ExpiresIn(3600)), Some("my@example.com")))
+  }
+
+  fixture("/default/missing").test("TokenProvider.auto falls back to metadata server when no ADC file is found") { _ =>
+    val client = Client.from {
+      case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "token"
+          if req.hasHeader("Metadata-Flavor", "Google") =>
+        Ok(Json.obj("access_token" := "metadata-token", "expires_in" := 3600))
+      case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "email"
+          if req.hasHeader("Metadata-Flavor", "Google") =>
+        Ok("metadata-sa@project.iam.gserviceaccount.com")
+    }
+
+    val result = TokenProvider.auto[IO](client).flatMap { provider =>
+      (provider.accessToken, provider.principal).tupled
+    }
+
+    assertIO(
+      result,
+      (AccessToken(Token("metadata-token"), ExpiresIn(3600)), Some("metadata-sa@project.iam.gserviceaccount.com"))
+    )
+  }
+
+  ///////////////////////////////////////////////
+  // TokenProvider.auto (identity-token flavor) //
+  ///////////////////////////////////////////////
+
+  fixture("/default/valid").test("TokenProvider.auto(client, audience) routes to userIdentity when ADC file exists") {
+    _ =>
+      val idToken = JwtCirce.encode(JwtClaim(content = Json.obj("email" := "adc-user@example.com").noSpaces))
+
+      val client = Client.from { case POST -> Root / "token" =>
+        Ok(Json.obj("id_token" := idToken, "expires_in" := 3600))
+      }
+
+      val audience = uri"http://example.com/my-audience"
+
+      val result = TokenProvider.auto[IO](client, audience).flatMap(_.principal)
+
+      assertIO(result, Some("adc-user@example.com"))
+  }
+
+  fixture("/default/missing")
+    .test("TokenProvider.auto(client, audience) falls back to metadata server when no ADC file is found") { _ =>
+      val audience = uri"http://example.com/my-audience"
+
+      val expiration = Instant.now().plusSeconds(60).getEpochSecond()
+
+      val client = Client.from {
+        case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "identity"
+            if req.hasParam("audience", audience.renderString) && req.hasHeader("Metadata-Flavor", "Google") =>
+          Ok(JwtCirce.encode(JwtClaim(expiration = expiration.some)))
+        case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "email"
+            if req.hasHeader("Metadata-Flavor", "Google") =>
+          Ok("metadata-sa@project.iam.gserviceaccount.com")
+      }
+
+      val result = TokenProvider.auto[IO](client, audience).flatMap(_.principal)
+
+      assertIO(result, Some("metadata-sa@project.iam.gserviceaccount.com"))
+    }
+
+  fixture("/default/external")
+    .test("TokenProvider.auto raises UnableToGetDefaultCredentials for non-SA / non-user types") { _ =>
+      val client = Client.from(PartialFunction.empty)
+
+      val result = TokenProvider.auto[IO](client).flatMap(_.accessToken).attempt
+
+      result.map {
+        case Left(_: UnableToGetDefaultCredentials) => ()
+        case other                                  => fail(s"expected UnableToGetDefaultCredentials, got: $other")
+      }
+    }
+
+  fixture("/default/sa-valid")
+    .test("TokenProvider.auto(client, audience) raises UnsupportedCredentialsType for service_account") { _ =>
+      val audience = uri"http://example.com/my-audience"
+      val client   = Client.from(PartialFunction.empty)
+
+      val result = TokenProvider.auto[IO](client, audience).flatMap(_.accessToken).attempt
+
+      result.map {
+        case Left(_: UnsupportedCredentialsType) => ()
+        case other                               => fail(s"expected UnsupportedCredentialsType, got: $other")
+      }
+    }
+
+  fixture("/default/missing").test("TokenProvider.auto memoises principal across calls") { _ =>
+    val counter = new AtomicInteger(0)
+
+    val client = Client.from {
+      case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "token"
+          if req.hasHeader("Metadata-Flavor", "Google") =>
+        Ok(Json.obj("access_token" := "tok", "expires_in" := 3600))
+      case req @ GET -> Root / "computeMetadata" / "v1" / "instance" / "service-accounts" / "default" / "email"
+          if req.hasHeader("Metadata-Flavor", "Google") =>
+        IO(counter.incrementAndGet()) *> Ok("metadata-sa@project.iam.gserviceaccount.com")
+    }
+
+    val result = TokenProvider.auto[IO](client).flatMap { provider =>
+      provider.principal.replicateA(5).map(_ => counter.get())
+    }
+
+    assertIO(result, 1)
   }
 
   /////////////////////////////////////////

--- a/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
+++ b/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
@@ -561,6 +561,33 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       }
     }
 
+  /////////////////////////////////////
+  // TokenProvider.auto disable      //
+  /////////////////////////////////////
+
+  def disableFixture = ResourceFunFixture {
+    Resource.make(IO(sys.props.put("gcp.auth.disable", "true")).void)(_ =>
+      IO(sys.props.remove("gcp.auth.disable")).void
+    )
+  }
+
+  disableFixture.test("TokenProvider.auto(client) short-circuits to AccessToken.noop when disabled") { _ =>
+    val client = Client.fromHttpApp(HttpApp.notFound[IO])
+
+    assertIO(TokenProvider.auto[IO](client).flatMap(_.accessToken), AccessToken.noop)
+  }
+
+  disableFixture.test("TokenProvider.auto(client, audience) short-circuits to AccessToken.noop when disabled") { _ =>
+    val client   = Client.fromHttpApp(HttpApp.notFound[IO])
+    val audience = uri"http://example.com/my-audience"
+
+    assertIO(TokenProvider.auto[IO](client, audience).flatMap(_.accessToken), AccessToken.noop)
+  }
+
+  disableFixture.test("argless TokenProvider.auto[IO] short-circuits without allocating a JdkHttpClient") { _ =>
+    assertIO(TokenProvider.auto[IO].use(_.accessToken), AccessToken.noop)
+  }
+
   fixture("/default/missing").test("TokenProvider.auto memoises principal across calls") { _ =>
     val counter = new AtomicInteger(0)
 

--- a/project/dependencies.conf
+++ b/project/dependencies.conf
@@ -4,6 +4,7 @@ gcp-auth = [
   "com.permutive::refreshable:2.1.1"
   "org.http4s::http4s-circe:0.23.34"
   "org.http4s::http4s-client:0.23.34"
+  "org.http4s::http4s-jdk-http-client:0.10.0"
   "com.alejandrohdezma::http4s-munit:2.0.0:test"
 ]
 


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

Adds `TokenProvider.auto` — picks the right token provider using Google's standard [ADC precedence], dispatching on the credentials file's `"type"` field:

1. `service_account` JSON → `serviceAccount(email, key, scopes, httpClient)`
2. `authorized_user` JSON → `userAccount(clientId, clientSecret, refreshToken, httpClient)`
3. No file → metadata-server fallback (`serviceAccount(httpClient)` for access tokens, `identity(httpClient, audience)` for identity tokens)
4. Any other `"type"` → raises `UnsupportedCredentialsType` (e.g. `external_account`, `impersonated_service_account`, `gdch_service_account`).

Useful when the same binary runs locally (user account), in CI (service-account JSON via `GOOGLE_APPLICATION_CREDENTIALS`), and in production (workload identity on GCE/GKE).

Also includes:

- A new `userIdentity(clientId, clientSecret, refreshToken, httpClient)` overload mirroring the existing `userAccount` triple-overload — extracted so the principal-resolution / token-fetch logic lives in one place.
- Three argless `TokenProvider.auto` overloads that allocate a default `JdkHttpClient` internally and return a `Resource[F, TokenProvider[F]]`.

[ADC precedence]: https://cloud.google.com/docs/authentication/provide-credentials-adc