### PR TITLE
Capture absolute `expiresAt` on `AccessToken`

### DIFF
--- a/modules/gcp-auth-pureconfig/src/test/scala/com/permutive/gcp/auth/pureconfig/TypeTokenSuite.scala
+++ b/modules/gcp-auth-pureconfig/src/test/scala/com/permutive/gcp/auth/pureconfig/TypeTokenSuite.scala
@@ -20,7 +20,6 @@ import cats.effect.IO
 import cats.effect.Resource
 
 import com.permutive.gcp.auth.models.AccessToken
-import com.permutive.gcp.auth.models.ExpiresIn
 import com.permutive.gcp.auth.models.Token
 import io.circe.Json
 import io.circe.syntax._
@@ -49,7 +48,7 @@ class TypeTokenSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .tokenProvider(client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenType.ServiceAccount can be loaded from configuration") {
@@ -66,7 +65,7 @@ class TypeTokenSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .tokenProvider(client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenType.NoOp can be loaded from configuration") {

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/TokenProvider.scala
@@ -53,7 +53,6 @@ import com.permutive.gcp.auth.models.Token
 import com.permutive.refreshable.Refreshable
 import fs2.io.file.Files
 import fs2.io.file.Path
-import io.circe.Decoder
 import io.circe.Json
 import io.circe.parser
 import org.http4s.EntityDecoder
@@ -215,10 +214,12 @@ object TokenProvider {
         .googleExpect[String](uri"identity" +? ("audience" -> audience))
         .mproduct(JwtCirce.decode(_, jwtOptions).toEither.flatMap(_.expiration.toRight(ExpirationNotFound)).liftTo[F])
         .flatMap { case (token, expiration) =>
+          val expiresAt = Instant.ofEpochSecond(expiration)
+
           Clock[F].realTimeInstant
-            .map(now => Duration.between(now, Instant.ofEpochSecond(expiration)).toSeconds())
+            .map(now => Duration.between(now, expiresAt).toSeconds())
             .map(ExpiresIn(_))
-            .map(AccessToken(Token(token), _))
+            .map(AccessToken(Token(token), _, expiresAt))
         }
         .adaptError { case t => new UnableToGetToken(t) }
     }
@@ -264,7 +265,7 @@ object TokenProvider {
     * @see
     *   https://cloud.google.com/run/docs/securing/service-identity#fetching_identity_and_access_tokens_using_the_metadata_server
     */
-  def userIdentity[F[_]: Concurrent](
+  def userIdentity[F[_]: Concurrent: Clock](
       clientId: ClientId,
       clientSecret: ClientSecret,
       refreshToken: RefreshToken,
@@ -280,11 +281,8 @@ object TokenProvider {
 
       val request = Request[F](POST, uri"https://oauth2.googleapis.com/token").withEntity(form)
 
-      val decoder = Decoder.forProduct2("id_token", "expires_in")(AccessToken.apply)
-
       httpClient
-        .expect[Json](request)
-        .flatMap(_.as[AccessToken](decoder).liftTo[F])
+        .expect[AccessToken](request)
         .adaptError { case t => new UnableToGetToken(t) }
     }
 
@@ -318,7 +316,7 @@ object TokenProvider {
     * @see
     *   https://cloud.google.com/compute/docs/access/authenticate-workloads
     */
-  def serviceAccount[F[_]: Concurrent](httpClient: Client[F]): F[TokenProvider[F]] = {
+  def serviceAccount[F[_]: Concurrent: Clock](httpClient: Client[F]): F[TokenProvider[F]] = {
     val fetchToken =
       httpClient.googleExpect[AccessToken](uri"token").adaptError { case t => new UnableToGetToken(t) }
 
@@ -389,7 +387,7 @@ object TokenProvider {
     * @see
     *   https://developers.google.com/identity/protocols/oauth2
     */
-  def userAccount[F[_]: Concurrent: Files](
+  def userAccount[F[_]: Concurrent: Clock: Files](
       clientSecretsPath: Path,
       refreshTokenPath: Path,
       httpClient: Client[F]
@@ -407,7 +405,7 @@ object TokenProvider {
     * @see
     *   https://developers.google.com/identity/protocols/oauth2
     */
-  def userAccount[F[_]: Concurrent](
+  def userAccount[F[_]: Concurrent: Clock](
       clientId: ClientId,
       clientSecret: ClientSecret,
       refreshToken: RefreshToken,

--- a/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/models/AccessToken.scala
+++ b/modules/gcp-auth/src/main/scala/com/permutive/gcp/auth/models/AccessToken.scala
@@ -16,24 +16,31 @@
 
 package com.permutive.gcp.auth.models
 
+import java.time.Instant
+
+import cats.effect.Clock
 import cats.effect.Concurrent
 import cats.syntax.all._
 
 import io.circe.Decoder
 import org.http4s.AuthScheme
 import org.http4s.Credentials
+import org.http4s.DecodeResult
 import org.http4s.EntityDecoder
 import org.http4s.circe.jsonOf
 import org.http4s.headers.Authorization
 
-sealed abstract class AccessToken(val token: Token, val expiresIn: ExpiresIn) extends Serializable {
+sealed abstract class AccessToken(val token: Token, val expiresIn: ExpiresIn, val expiresAt: Instant)
+    extends Serializable {
 
-  override def toString(): String = show"AccessToken(token=REDACTED,expiresIn=$expiresIn"
+  override def toString(): String = s"AccessToken(token=REDACTED,expiresIn=$expiresIn,expiresAt=$expiresAt)"
 
   override def equals(obj: Any): Boolean = obj match {
-    case a: AccessToken => a.token === token && a.expiresIn === expiresIn
+    case a: AccessToken => a.token === token && a.expiresIn === expiresIn && a.expiresAt.equals(expiresAt)
     case _              => false
   }
+
+  override def hashCode(): Int = (token, expiresIn, expiresAt).hashCode()
 
   def asHeader: Authorization = Authorization(Credentials.Token(AuthScheme.Bearer, token.value))
 
@@ -41,17 +48,43 @@ sealed abstract class AccessToken(val token: Token, val expiresIn: ExpiresIn) ex
 
 object AccessToken {
 
-  def apply(token: Token, expiresIn: ExpiresIn): AccessToken = new AccessToken(token, expiresIn) {}
+  /** Constructs an `AccessToken` from a token value, its lifetime (seconds-of-validity from Google), and its absolute
+    * deadline.
+    *
+    * Callers are responsible for keeping `expiresIn` and `expiresAt` consistent — `expiresAt` should equal "fetch time
+    * + expiresIn". The wire-format entity decoder and the in-tree factories do this for you.
+    */
+  def apply(token: Token, expiresIn: ExpiresIn, expiresAt: Instant): AccessToken =
+    new AccessToken(token, expiresIn, expiresAt) {}
 
-  def unapply(token: AccessToken): Some[(Token, ExpiresIn)] = Some((token.token, token.expiresIn))
+  def unapply(token: AccessToken): Some[(Token, ExpiresIn, Instant)] =
+    Some((token.token, token.expiresIn, token.expiresAt))
 
-  lazy val noop = new AccessToken(Token("noop"), ExpiresIn(3600)) {}
+  /** A sentinel access token whose deadline is set far enough in the future that it will never expire in practice.
+    * Intended for tests and no-op token providers — not a valid Google token.
+    */
+  lazy val noop: AccessToken = AccessToken(Token("noop"), ExpiresIn(3600), Instant.MAX)
 
-  implicit val AccessTokenDecoder: Decoder[AccessToken] =
-    Decoder.forProduct2[AccessToken, Token, ExpiresIn]("access_token", "expires_in") { (token, expiresIn) =>
-      new AccessToken(token, expiresIn) {}
+  /** Wire format Google sends back from its OAuth endpoints. Used only by [[AccessTokenEntityDecoder]] to recover the
+    * `expires_in` relative duration so the absolute deadline can be fixed against the current clock.
+    */
+  private case class Response(token: Token, expiresIn: ExpiresIn)
+
+  implicit private val ResponseDecoder: Decoder[Response] =
+    Decoder
+      .forProduct2("access_token", "expires_in")(Response.apply)
+      .or(Decoder.forProduct2("id_token", "expires_in")(Response.apply))
+
+  /** Decodes Google's `(access_token, expires_in)` response and fixes the absolute deadline at decode time using the
+    * current clock — so the resulting `expiresAt` does not drift if the token is cached and re-read later.
+    */
+  implicit def AccessTokenEntityDecoder[F[_]: Concurrent: Clock]: EntityDecoder[F, AccessToken] =
+    jsonOf[F, Response].flatMapR { response =>
+      DecodeResult.success {
+        Clock[F].realTimeInstant.map(now =>
+          AccessToken(response.token, response.expiresIn, now.plusSeconds(response.expiresIn.value))
+        )
+      }
     }
-
-  implicit def AccessTokenEntityDecoder[F[_]: Concurrent]: EntityDecoder[F, AccessToken] = jsonOf[F, AccessToken]
 
 }

--- a/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
+++ b/modules/gcp-auth/src/test/scala/com/permutive/gcp/auth/TokenProviderSuite.scala
@@ -34,7 +34,6 @@ import com.permutive.gcp.auth.models.AccessToken
 import com.permutive.gcp.auth.models.ClientEmail
 import com.permutive.gcp.auth.models.ClientId
 import com.permutive.gcp.auth.models.ClientSecret
-import com.permutive.gcp.auth.models.ExpiresIn
 import com.permutive.gcp.auth.models.RefreshToken
 import com.permutive.gcp.auth.models.Token
 import fs2.Stream
@@ -86,7 +85,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       token         <- tokenProvider.accessToken
     } yield {
       assert(token.token.value.nonEmpty)
-      assert(token.expiresIn.value <= 60)
+      assertEquals(token.expiresAt, Instant.ofEpochSecond(expiration))
     }
   }
 
@@ -140,9 +139,13 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
     for {
       tokenProvider <- TokenProvider.userIdentity[IO](client)
       token         <- tokenProvider.accessToken
+      now           <- IO.realTimeInstant
     } yield {
       assert(token.token.value.nonEmpty)
-      assertEquals(token.expiresIn.value, 3600L)
+      assert(
+        token.expiresAt.isAfter(now.plusSeconds(3598)) && token.expiresAt.isBefore(now.plusSeconds(3601)),
+        s"expected expiresAt ~3600s from now, got: ${token.expiresAt}"
+      )
     }
   }
 
@@ -183,7 +186,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
 
     val result = TokenProvider.serviceAccount[IO](client).flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenProvider.serviceAccount(Client) returns an error on any failure") {
@@ -207,7 +210,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .serviceAccount[IO](path, "scope_1" :: "scope_2" :: Nil, client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenProvider.serviceAccount(Path, List[String], Client) returns an error on any failure") {
@@ -262,7 +265,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
 
     val result = tokenProvider.accessToken
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test {
@@ -293,7 +296,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .userAccount[IO](client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   fixture("/").test {
@@ -323,7 +326,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .userAccount[IO](ClientId("client_id"), ClientSecret("client_secret"), RefreshToken("refresh_token"), client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenProvider.userAccount(ClientId, ClientSecret, RefreshToken, Client) retuns an error on any failure") {
@@ -352,7 +355,7 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
       .userAccount[IO](clientSecretsPath, refreshTokenPath, client)
       .flatMap(_.accessToken)
 
-    assertIO(result, AccessToken(Token("token"), ExpiresIn(3600)))
+    assertIO(result.map(_.token), Token("token"))
   }
 
   test("TokenProvider.userAccount(Path, Path, Client) retuns an error on any failure") {
@@ -459,10 +462,10 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
     }
 
     val result = TokenProvider.auto[IO](client).flatMap { provider =>
-      (provider.accessToken, provider.principal).tupled
+      (provider.accessToken.map(_.token), provider.principal).tupled
     }
 
-    assertIO(result, (AccessToken(Token("user-token"), ExpiresIn(3600)), Some("adc-user@example.com")))
+    assertIO(result, (Token("user-token"), Some("adc-user@example.com")))
   }
 
   fixture("/default/sa-valid").test("TokenProvider.auto routes to serviceAccount when ADC SA file exists") { _ =>
@@ -471,10 +474,10 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
     }
 
     val result = TokenProvider.auto[IO](client).flatMap { provider =>
-      (provider.accessToken, provider.principal).tupled
+      (provider.accessToken.map(_.token), provider.principal).tupled
     }
 
-    assertIO(result, (AccessToken(Token("sa-token"), ExpiresIn(3600)), Some("my@example.com")))
+    assertIO(result, (Token("sa-token"), Some("my@example.com")))
   }
 
   fixture("/default/missing").test("TokenProvider.auto falls back to metadata server when no ADC file is found") { _ =>
@@ -488,13 +491,10 @@ class TokenProviderSuite extends CatsEffectSuite with Http4sMUnitSyntax {
     }
 
     val result = TokenProvider.auto[IO](client).flatMap { provider =>
-      (provider.accessToken, provider.principal).tupled
+      (provider.accessToken.map(_.token), provider.principal).tupled
     }
 
-    assertIO(
-      result,
-      (AccessToken(Token("metadata-token"), ExpiresIn(3600)), Some("metadata-sa@project.iam.gserviceaccount.com"))
-    )
+    assertIO(result, (Token("metadata-token"), Some("metadata-sa@project.iam.gserviceaccount.com")))
   }
 
   ///////////////////////////////////////////////


### PR DESCRIPTION
## :rocket: What's included in this PR?

Adds an `expiresAt: Instant` field to `AccessToken` alongside the existing `expiresIn: ExpiresIn` and fixes the absolute deadline at fetch time. The http4s entity decoder reads the wire-format `(access_token, expires_in)` response (also accepting `id_token` via an `.or` alternative) and computes `expiresAt = now + expires_in` via `Clock`.

This eliminates a subtle drift bug: callers that cached an `AccessToken` and later computed `now + token.expiresIn` ended up overstating the deadline by however long the token had been cached. Reading `token.expiresAt` directly gives the fetch-time-fixed deadline.

`identity` and `userIdentity` factories now thread `expiresAt` through. `userIdentity(triple)` collapses to a single `httpClient.expect[AccessToken]` call since the entity decoder handles both `access_token` and `id_token` response shapes. `safetyPeriod` is unchanged.

Test assertions that compared full `AccessToken` instances were loosened to compare only the `Token` value (Approach 1) so they don't have to fabricate matching `Instant`s.