### PR TITLE
Add `gcp-auth-kafka` module

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -296,6 +296,37 @@ val tokenProvider = config.tokenType.tokenProvider(httpClient)
 val identityTokenProvider = config.tokenType.identityTokenProvider(httpClient, myAudience)
 ```
 
+### Authenticating with Google Managed Kafka
+
+The library also provides a SASL/OAUTHBEARER login callback handler for
+[Google Managed Service for Apache Kafka]. It is a drop-in replacement for
+Google's `com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler` that
+uses `gcp-auth`'s `TokenProvider.auto` under the hood — no
+`kafka-schema-registry-client`, no Google Java SDK on the classpath.
+
+1. Add the following line to your `build.sbt` file:
+
+```sbt
+libraryDependencies += "@ORGANIZATION@" %% "@NAME@-kafka" % "@VERSION@"
+```
+
+2. Wire it into your Kafka client config:
+
+```properties
+security.protocol                 = SASL_SSL
+sasl.mechanism                    = OAUTHBEARER
+sasl.login.callback.handler.class = com.permutive.gcp.auth.kafka.GcpLoginCallbackHandler
+sasl.jaas.config                  = org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+```
+
+The handler resolves credentials using ADC precedence (via
+`TokenProvider.auto`). The `sub` claim is taken from
+`GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL` when set (overrides the provider's
+principal — useful for Workforce Identity Federation cases), otherwise
+from the provider's `principal`. If neither yields a value, `configure`
+raises `IllegalStateException` pointing at the env var (matching Google's
+fail-fast behavior).
+
 ## Contributors to this project
 
 @CONTRIBUTORS_TABLE@
@@ -307,4 +338,5 @@ val identityTokenProvider = config.tokenType.identityTokenProvider(httpClient, m
 [Identity Token]: https://cloud.google.com/run/docs/securing/service-identity#fetching_identity_and_access_tokens_using_the_metadata_server
 [instance metadata API]: https://cloud.google.com/compute/docs/access/authenticate-workloads
 [ADC precedence]: https://cloud.google.com/docs/authentication/provide-credentials-adc
+[Google Managed Service for Apache Kafka]: https://cloud.google.com/managed-service-for-apache-kafka/docs
 [pureconfig]: https://pureconfig.github.io

--- a/build.sbt
+++ b/build.sbt
@@ -9,11 +9,15 @@ addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 
 lazy val documentation = project
   .enablePlugins(MdocPlugin)
-  .dependsOn(`gcp-auth`, `gcp-auth-pureconfig`)
+  .dependsOn(`gcp-auth`, `gcp-auth-pureconfig`, `gcp-auth-kafka`)
 
 lazy val `gcp-auth` = module
   .settings(Test / fork := true)
 
 lazy val `gcp-auth-pureconfig` = module
+  .settings(Test / fork := true)
+  .dependsOn(`gcp-auth`)
+
+lazy val `gcp-auth-kafka` = module
   .settings(Test / fork := true)
   .dependsOn(`gcp-auth`)

--- a/modules/gcp-auth-kafka/src/main/scala/com/permutive/gcp/auth/kafka/GcpLoginCallbackHandler.scala
+++ b/modules/gcp-auth-kafka/src/main/scala/com/permutive/gcp/auth/kafka/GcpLoginCallbackHandler.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024-2025 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.permutive.gcp.auth.kafka
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import java.util.Base64
+import java.{util => j}
+
+import scala.jdk.CollectionConverters._
+
+import cats.effect.IO
+import cats.effect.std.Dispatcher
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+
+import com.permutive.gcp.auth.TokenProvider
+import com.permutive.gcp.auth.models.AccessToken
+import io.circe.Json
+import io.circe.syntax._
+import javax.security.auth.callback.Callback
+import javax.security.auth.callback.UnsupportedCallbackException
+import javax.security.auth.login.AppConfigurationEntry
+import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler
+import org.apache.kafka.common.security.auth.SaslExtensions
+import org.apache.kafka.common.security.auth.SaslExtensionsCallback
+import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback
+import org.apache.kafka.common.security.oauthbearer.internals.secured.BasicOAuthBearerToken
+
+/** Kafka SASL/OAUTHBEARER login callback handler for Google Managed Service for Apache Kafka.
+  *
+  * Drop-in replacement for Google's `com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler` that uses `gcp-auth`'s
+  * [[com.permutive.gcp.auth.TokenProvider TokenProvider]] under the hood — no `kafka-schema-registry-client`, no Google
+  * Java SDK on the classpath.
+  *
+  * Wire it into your Kafka client config:
+  * {{{
+  * security.protocol                 = SASL_SSL
+  * sasl.mechanism                    = OAUTHBEARER
+  * sasl.login.callback.handler.class = com.permutive.gcp.auth.kafka.GcpLoginCallbackHandler
+  * sasl.jaas.config                  = org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
+  * }}}
+  *
+  * The handler resolves credentials via `TokenProvider.auto` (ADC precedence). The `sub` claim is taken from
+  * `GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL` when set (overrides the provider's principal — useful for Workforce Identity
+  * Federation cases), otherwise from the provider's `principal`. If neither yields a value, [[configure]] raises an
+  * `IllegalStateException` pointing at the env var.
+  */
+@SuppressWarnings(Array("scalafix:DisableSyntax.var", "scalafix:DisableSyntax.throw"))
+class GcpLoginCallbackHandler extends AuthenticateCallbackHandler {
+
+  /** Returns a fresh access token on each call. Populated by [[configure]] — it bakes in the cached `TokenProvider`
+    * plus the dispatcher so [[handle]] can synchronously cross the cats-effect / Kafka SPI boundary.
+    */
+  private var fetchToken: () => AccessToken = _
+
+  /** Subject identifier baked in at [[configure]] time and used as the `sub` claim of every emitted token. Resolved
+    * once from `GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL` when set (overrides the provider's principal), otherwise from the
+    * provider's `principal`. If neither yields a value, [[configure]] raises an `IllegalStateException`.
+    */
+  private var sub: String = _
+
+  /** Finaliser that releases the resources allocated in [[configure]] (the dispatcher, the JDK http client, and the
+    * cached token-refresh fiber). Run from [[close]].
+    */
+  private var release: IO[Unit] = IO.unit
+
+  /** Set once [[configure]] succeeds. [[handle]] checks this and raises `IllegalStateException` when called first —
+    * matches the contract of Google's `GcpLoginCallbackHandler`.
+    */
+  private var configured: Boolean = false
+
+  override def configure(configs: j.Map[String, _], mechanism: String, entries: j.List[AppConfigurationEntry]) = {
+    require(mechanism === "OAUTHBEARER", s"Unexpected SASL mechanism: $mechanism")
+
+    val resources = for {
+      dispatcher <- Dispatcher.parallel[IO]
+      provider   <- TokenProvider.auto[IO].flatMap(TokenProvider.cached[IO].build(_))
+    } yield {
+      fetchToken = () => dispatcher.unsafeRunSync(provider.accessToken)
+
+      sub = sys.env.get("GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL").filter(_.nonEmpty).getOrElse {
+        dispatcher.unsafeRunSync(provider.principal).getOrElse {
+          throw new IllegalStateException(
+            "Unable to determine principal for credentials. " +
+              "Please set the GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL environment variable."
+          )
+        }
+      }
+    }
+
+    release = resources.allocated.unsafeRunSync()._2
+    configured = true
+  }
+
+  override def handle(callbacks: Array[Callback]): Unit = {
+    if (!configured) throw new IllegalStateException("Callback handler not configured")
+
+    callbacks.foreach {
+      case cb: OAuthBearerTokenCallback => cb.token(buildKafkaToken(fetchToken, sub))
+      case cb: SaslExtensionsCallback   => cb.extensions(SaslExtensions.empty())
+      case other                        => throw new UnsupportedCallbackException(other)
+    }
+  }
+
+  override def close(): Unit = release.unsafeRunSync()
+
+  private[kafka] def buildKafkaToken(fetchToken: () => AccessToken, sub: String): BasicOAuthBearerToken = {
+    val token = fetchToken()
+
+    val now    = Instant.now()
+    val expSec = token.expiresAt.getEpochSecond
+
+    val header  = Json.obj("typ" := "JWT", "alg" := "GOOG_OAUTH2_TOKEN")
+    val payload = Json.obj("exp" := expSec, "iat" := now.getEpochSecond, "scope" := "kafka", "sub" := sub)
+
+    val envelope = Seq(header.noSpaces, payload.noSpaces, token.token.value)
+      .map(_.getBytes(UTF_8))
+      .map(Base64.getUrlEncoder.withoutPadding.encodeToString)
+      .mkString(".")
+
+    new BasicOAuthBearerToken(envelope, Set("kafka").asJava, expSec * 1000L, sub, now.toEpochMilli)
+  }
+
+}

--- a/modules/gcp-auth-kafka/src/test/scala/com/permutive/gcp/auth/kafka/GcpLoginCallbackHandlerSuite.scala
+++ b/modules/gcp-auth-kafka/src/test/scala/com/permutive/gcp/auth/kafka/GcpLoginCallbackHandlerSuite.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024-2025 Permutive Ltd. <https://permutive.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.permutive.gcp.auth.kafka
+
+import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Instant
+import java.util.Base64
+
+import scala.jdk.CollectionConverters._
+
+import com.permutive.gcp.auth.models.AccessToken
+import com.permutive.gcp.auth.models.ExpiresIn
+import com.permutive.gcp.auth.models.Token
+import io.circe.parser
+import munit.FunSuite
+import org.apache.kafka.common.security.auth.SaslExtensionsCallback
+
+class GcpLoginCallbackHandlerSuite extends FunSuite {
+
+  test("buildKafkaToken produces the GOOG_OAUTH2_TOKEN envelope") {
+    val handler = new GcpLoginCallbackHandler
+
+    val expiresAt = Instant.now().plusSeconds(3600)
+
+    val before = Instant.now().getEpochSecond
+    val token  = handler.buildKafkaToken(
+      () => AccessToken(Token("the-google-token"), ExpiresIn(3600), expiresAt),
+      "sa@x.iam.gserviceaccount.com"
+    )
+    val after = Instant.now().getEpochSecond
+
+    val segments = token.value().split('.')
+    assertEquals(segments.length, 3, s"expected three dot-separated segments, got: ${token.value()}")
+
+    val headerB64    = segments(0)
+    val payloadB64   = segments(1)
+    val signatureB64 = segments(2)
+
+    val header = new String(Base64.getUrlDecoder.decode(headerB64), UTF_8)
+    assertEquals(header, """{"typ":"JWT","alg":"GOOG_OAUTH2_TOKEN"}""")
+
+    val payloadJson = new String(Base64.getUrlDecoder.decode(payloadB64), UTF_8)
+    val payload     = parser.parse(payloadJson).toOption.flatMap(_.asObject).getOrElse(fail("payload is not a JSON object"))
+
+    assertEquals(payload("scope").flatMap(_.asString), Some("kafka"))
+    assertEquals(payload("sub").flatMap(_.asString), Some("sa@x.iam.gserviceaccount.com"))
+
+    val iat = payload("iat").flatMap(_.asNumber).flatMap(_.toLong).getOrElse(fail("iat is missing"))
+    val exp = payload("exp").flatMap(_.asNumber).flatMap(_.toLong).getOrElse(fail("exp is missing"))
+
+    assert(iat >= before && iat <= after, s"iat=$iat should be between $before and $after")
+    assertEquals(exp, expiresAt.getEpochSecond)
+
+    val signature = new String(Base64.getUrlDecoder.decode(signatureB64), UTF_8)
+    assertEquals(signature, "the-google-token")
+  }
+
+  test("buildKafkaToken sets BasicOAuthBearerToken fields") {
+    val handler = new GcpLoginCallbackHandler
+
+    val expiresAt = Instant.now().plusSeconds(3600)
+
+    val token =
+      handler.buildKafkaToken(() => AccessToken(Token("tok"), ExpiresIn(3600), expiresAt), "principal@example.com")
+
+    assertEquals(token.scope().asScala.toSet, Set("kafka"))
+    assertEquals(token.principalName(), "principal@example.com")
+    assertEquals(token.lifetimeMs(), expiresAt.getEpochSecond * 1000L)
+  }
+
+  test("configure rejects non-OAUTHBEARER mechanisms") {
+    val handler = new GcpLoginCallbackHandler
+
+    intercept[IllegalArgumentException] {
+      handler.configure(new java.util.HashMap[String, AnyRef], "PLAIN", java.util.Collections.emptyList())
+    }
+  }
+
+  test("handle before configure throws IllegalStateException") {
+    val handler = new GcpLoginCallbackHandler
+
+    intercept[IllegalStateException] {
+      handler.handle(Array(new SaslExtensionsCallback))
+    }
+  }
+
+}

--- a/project/dependencies.conf
+++ b/project/dependencies.conf
@@ -12,3 +12,8 @@ gcp-auth-pureconfig = [
   "com.github.pureconfig::pureconfig-core:0.17.10"
   "com.alejandrohdezma::http4s-munit:2.0.0:test"
 ]
+
+gcp-auth-kafka = [
+  "org.apache.kafka:kafka-clients:4.2.0:provided"
+  "com.alejandrohdezma::http4s-munit:2.0.0:test"
+]


### PR DESCRIPTION
## :rocket: What's included in this PR?

Ships a sibling module that provides a Kafka SASL/OAUTHBEARER login callback handler for [Google Managed Service for Apache Kafka].

`com.permutive.gcp.auth.kafka.GcpLoginCallbackHandler` is a drop-in replacement for Google's `com.google.cloud.hosted.kafka.auth.GcpLoginCallbackHandler` that builds on \`gcp-auth\`'s \`TokenProvider.auto\` and \`TokenProvider#principal\` — no \`kafka-schema-registry-client\`, no Google Java SDK on the classpath, and \`kafka-clients\` is published as \`provided\` so the consumer picks its own Kafka version.

The \`sub\` claim is resolved once at \`configure\` time from \`GOOGLE_MANAGED_KAFKA_AUTH_PRINCIPAL\` when set (overrides the provider's principal, useful for Workforce Identity Federation), otherwise from the provider's \`principal\`. If neither yields a value, \`configure\` raises \`IllegalStateException\` pointing at the env var (matching Google's fail-fast behavior). \`handle\` before \`configure\` also raises \`IllegalStateException\`.

Wire it into your Kafka client config:

\`\`\`properties
security.protocol                 = SASL_SSL
sasl.mechanism                    = OAUTHBEARER
sasl.login.callback.handler.class = com.permutive.gcp.auth.kafka.GcpLoginCallbackHandler
sasl.jaas.config                  = org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;
\`\`\`

[Google Managed Service for Apache Kafka]: https://cloud.google.com/managed-service-for-apache-kafka/docs